### PR TITLE
feature/github-workflow-cypress

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Run Cypress E2E Testing
+
+on: push
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install modules
+        run: npm ci
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        with:
+          browser: chrome
+          headless: true
+          start: npm run dev
+          wait-on: http://localhost:5173

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,5 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           browser: chrome
-          headless: true
           start: npm run dev
           wait-on: http://localhost:5173

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
# Related Issue / Feature

- Being able to run Cypress E2E testing on push to the repository.

# Proposed Changes

- Created a GitHub workflow action to auto-run the Cypress E2E testing upon pushing to the main branch.

# Additional Info

- N/A

# Checklist

- [ ] Unit testing for the proposed changes
- [ ] Unit testing for existing cases
- [ ] E2E testing for the proposed changes
- [ ] E2E testing for existing cases
- [ ] Updated the documentation
