### PR TITLE
feature/github-workflow-cypress 

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,23 @@
+name: Cypress Tests
+on: [push]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2] # Uses 2 parallel instances
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Cypress run
+        uses: cypress-io/github-action@v4
+        with:
+          start: npm run dev
+          wait-on: 'http://localhost:5173'
+          # Records to Cypress Cloud 
+          record: true
+          parallel: true
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Related Issue / Feature

- Being able to run Cypress E2E testing on push to the repository and save it to the cloud.

# Proposed Changes

- Created a GitHub workflow action to auto-run the Cypress E2E testing upon pushing to the main branch which will be recorded and saved to the cloud.

# Additional Info

- N/A

# Checklist

- [ ] Unit testing for the proposed changes
- [ ] Unit testing for existing cases
- [ ] E2E testing for the proposed changes
- [ ] E2E testing for existing cases
- [ ] Updated the documentation
